### PR TITLE
py3.6 support for `unicode` & ability to pass in HTTP-headers via the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ output/
 build/
 
 .DS_Store
+
+
+# PyCharm
+.idea/*


### PR DESCRIPTION
Added the ridiculously-hacky-but-necessary `sys.version_info` check b/c the python ppl got rid of the `unicode` keyword as of py3.6...don't even get me started.

Also added the ability to pass in our own headers via the `analyze()` API method that's already exposed. Didn't change any preexisting logic, but now the option is there in case one wants to specify a different `'User-Agent'` or something.

